### PR TITLE
Fixed next() iterator for non square matrix

### DIFF
--- a/src/main/kotlin/board/Matrix.kt
+++ b/src/main/kotlin/board/Matrix.kt
@@ -29,7 +29,7 @@ class Matrix<T>(
 
         override fun next(): T {
             if (!this.hasNext()) throw NoSuchElementException()
-            return entries[idx / n][idx++ % m]
+            return entries[idx / m][idx++ % m]
         }
     }
 


### PR DESCRIPTION
This fixes an issue that is apparent only if the board isn't square, f.e. Capablanca Chess (10x8).
It obviously never happens in Chezz as it provides support for standard Chess only, but for the sake of correctness here's a fix.